### PR TITLE
optimize 버그 수정 (Fixes #16)

### DIFF
--- a/aheui/compile.py
+++ b/aheui/compile.py
@@ -500,7 +500,7 @@ class Compiler(object):
                         break
                 if op == c.OP_BRPOP1 or op == c.OP_BRPOP2:
                     reqsize = c.OP_REQSIZE[op]
-                    if stacksize >= reqsize:
+                    if min_stacksizes[selected] >= reqsize:
                         pc += 1
                         continue
                     else:

--- a/aheui/compile.py
+++ b/aheui/compile.py
@@ -579,7 +579,7 @@ class Compiler(object):
                        b1                  b2           b3        x       b4
                     """
                     size = ix - i + 1
-                    diff = f - size
+                    diff = f - ix
                     for label, dest in self.label_map.items():
                         if i <= dest <= ix:  # b2
                             self.label_map[label] += diff - 1


### PR DESCRIPTION
- optimize_order에 오타가 있어서 jmp 주소가 코드 밖으로 나가 버렸던 문제를 고쳤습니다. (#16 에서 Segmentation fault / IndexError 가 났던 원인입니다.)
- optimize_deadcode2에서 코너 케이스에 생기는 버그를 고쳤습니다. BRPOP을 2번째 방문하는데 다른 스택이 줄어들어 있는 경우가 있습니다. 그 때에는 BRPOP 너머에 있는 코드도 다시 확인하도록 job_queue에 넣어야 하지만, 코너 케이스로 현재 스택이 충분히 차 있는 경우 optimizer는 BRPOP을 무시하고 다음 코드로 전진하도록 되어 있었습니다.

기존:
```bash
$ ./rpaheui-c -O2 snippets/pi/pi.jinseo.aheui
Segmentation fault (core dumped)

$ pypy ~/rpaheui/rpaheui.py -O2 snippets/pi/pi.jinseo.aheui
...
IndexError: list index out of range

# 또는

$ pypy ~/rpaheui/rpaheui.py -O2 snippets/pi/pi.jinseo.aheui
3.141
...
AttributeError: 'NoneType' object has no attribute 'next'
```

개선:
```bash
$ ./rpaheui-c -O1 snippets/pi/pi.jinseo.aheui
3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679821480865132823066470938446095505822317253594081284811174502841027019385211055596446229489549303819644288109756659334461284756482337867831652712019091456485669234603486104543266482133936072602491412737245870066063155881748815209209628292540917153643678925903600113305305488204665213841469519415116094330572703657595919530921861173819326117931051185480744623799627495673518857527248912279381830119491298336733624406566430860213949463952247371907021798609437027705392171762931767523846748184676694051320005681271452635608277857713427577896091736371787214684409012249534301465495853710507922796892589235420199561121290219608640344181598136297747713099605187072113499999983729780499510597317328160963185950244594553469083026425223082533446850352619311881710100031378387528865875332083814206171776691473035982534904287554687311595628638823537875937519577818577805321712268066130019278766111959092164201989380
$ ./rpaheui-c -O2 snippets/pi/pi.jinseo.aheui
3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679821480865132823066470938446095505822317253594081284811174502841027019385211055596446229489549303819644288109756659334461284756482337867831652712019091456485669234603486104543266482133936072602491412737245870066063155881748815209209628292540917153643678925903600113305305488204665213841469519415116094330572703657595919530921861173819326117931051185480744623799627495673518857527248912279381830119491298336733624406566430860213949463952247371907021798609437027705392171762931767523846748184676694051320005681271452635608277857713427577896091736371787214684409012249534301465495853710507922796892589235420199561121290219608640344181598136297747713099605187072113499999983729780499510597317328160963185950244594553469083026425223082533446850352619311881710100031378387528865875332083814206171776691473035982534904287554687311595628638823537875937519577818577805321712268066130019278766111959092164201989380
```