### PR TITLE
build-jit 깨지던 문제 수정

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           repository: pypy/pypy
-          ref: release-pypy2.7-v7.3.10
+          ref: release-pypy2.7-v7.3.9
           path: pypy
       - name: Build
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           repository: pypy/pypy
-          ref: release-pypy2.7-v7.3.13
+          ref: release-pypy2.7-v7.3.10
           path: pypy
       - name: Build
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,9 +55,13 @@ jobs:
         with:
           repository: pypy/pypy
           ref: release-pypy2.7-v7.3.13
+          path: pypy
       - name: Build
         run: |
-          RPYTHON=pypy/pypy/rpython/bin/rpython make
+          export RPYTHON="pypy $GITHUB_WORKSPACE/pypy/rpython/bin/rpython"
+          cd $GITHUB_WORKSPACE
+          make
       - name: Test with snippets
         run: |
-          cd snippets && AHEUI=../rpaheui-c ./test.sh --disable logo integer
+          cd "$GITHUB_WORKSPACE/snippets"
+          AHEUI="$GITHUB_WORKSPACE/rpaheui-c" ./test.sh --disable logo integer


### PR DESCRIPTION
경로 문제 때문에 make가 제대로 안 되던 문제를 수정했습니다.

그리고 빌드가 PyPy 7.3.10부터 깨지는 것을 확인했습니다.