### PR TITLE
trace_limit 제한 증가 (fix #27)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           repository: pypy/pypy
-          ref: release-pypy2.7-v7.3.9
+          ref: release-pypy2.7-v7.3.15
           path: pypy
       - name: Build
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 RPYTHON?=../pypy/rpython/bin/rpython
-RPYTHONFLAGS?=--opt=jit
+RPYTHONFLAGS?=--opt=jit --translation-jit_opencoder_model=big
 
 
 all: aheui-c aheui-py


### PR DESCRIPTION
#27 은 PyPy의 버그가 아니라 trace_limit의 최대치 기본값이 30000 미만이어서 생긴 문제였습니다.